### PR TITLE
Increase word count

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
       <h1>Call for Submissions</h1>
       <p>We invite the submission of bold, provocative, unusual, unconventional, thought-provoking works related to visualization in the broad sense. Authors should submit their work via OpenReview by <b>Friday, July 22nd, 2022</b> (submission not yet open). 
         Note that the submission itself does not need to have the form of a traditional conference paper: You are welcome to use any template format or medium that works for your submission. While alternative presentations (such as websites, videos, zines, or comics) are welcome, each work must include a PDF submission for archiving purposes including at least a title, author names*, an abstract. 
-        Traditionally written works should be no longer than 2500 words (not including references). 
+        Traditionally written works should be no longer than 4000 words (not including references). 
         Notifications of acceptance will be shared by <b>Wednesday, August 31st, 2022</b>.</p>
 
       <p>Examples of submissions we encourage include (but are not limited to):</p>

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
 
       <h1>Call for Submissions</h1>
       <p>We invite the submission of bold, provocative, unusual, unconventional, thought-provoking works related to visualization in the broad sense. Authors should submit their work via OpenReview by <b>Friday, July 22nd, 2022</b> (submission not yet open). 
-        Note that the submission itself does not need to have the form of a traditional conference paper: You are welcome to use any template format or medium that works for your submission. While alternative presentations (such as websites, videos, zines, or comics) are welcome, each work must include a PDF submission for archiving purposes including at least a title, author names*, an abstract. 
+        Note that the submission itself does not need to have the form of a traditional conference paper: You are welcome to use any template format or medium that works for your submission (this can include, but is not limited to, the familiar TVCG conference format). While alternative presentations (such as websites, videos, zines, or comics) are welcome, each work must include a PDF submission for archiving purposes including at least a title, author names*, an abstract. 
         Traditionally written works should be no longer than 4000 words (not including references). 
         Notifications of acceptance will be shared by <b>Wednesday, August 31st, 2022</b>.</p>
 


### PR DESCRIPTION
2500 word is quite a bit fewer than the submission limit of 5 pages last year, and seems to promote 2 page papers rather than 4 page papers. This increases that limit in order to promote similar papers this year as last year